### PR TITLE
fix: disable the native armcb isp driver

### DIFF
--- a/debian/patches/linux/0002-feat-Radxa-custom-kernel-config.patch
+++ b/debian/patches/linux/0002-feat-Radxa-custom-kernel-config.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] feat: Radxa custom kernel config
 
 Signed-off-by: ZHANG Yuntian <yt@radxa.com>
 ---
- src/arch/arm64/configs/radxa_custom.config | 13 +++++++++++++
- 1 file changed, 13 insertions(+)
+ src/arch/arm64/configs/radxa_custom.config | 16 +++++++++++++
+ 1 file changed, 16 insertions(+)
  create mode 100644 src/arch/arm64/configs/radxa_custom.config
 
 diff --git a/src/arch/arm64/configs/radxa_custom.config b/src/arch/arm64/configs/radxa_custom.config
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000000..c26829dd1cae
 --- /dev/null
 +++ b/src/arch/arm64/configs/radxa_custom.config
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,16 @@
 +# Closed source mali kernel module requires CONFIG_PREEMPT_RCU
 +CONFIG_PREEMPT_VOLUNTARY=n
 +CONFIG_PREEMPT=y
@@ -28,6 +28,9 @@ index 000000000000..c26829dd1cae
 +
 +# CIX drm_gpuvm.h is incompatible with nouveau
 +CONFIG_DRM_NOUVEAU=n
++
++# The built-in ISP driver has conflicts with the v4l2 ISP driver
++CONFIG_CAMERA_ARMCB=n
 -- 
 2.47.1
 


### PR DESCRIPTION

    fix: disable the native armcb isp driver
    
    There are two ISP drivers provided by CIX. One is a native driver in the
    kernel, called armcb_isp.ko when compiled as a module. The other one is
    called armcb_isp_v4l2.ko, which is maintained as an external module[0].
    The armcb_isp driver does not support V4L2 applications, such as Cheese
    or GStreamer, while the armcb_isp_v4l2 driver does.
    
    The armcb_isp was compiled as modules by default[1]. When both armcb_isp
    and armcb_isp_v4l2 drivers exist on the system, armcb_isp was found to
    be preferred, so the V4L2 applications don't work by default.
    
    To solve the issue, we disable the armcb_isp driver in the kernel
    config.
    
    [0]: https://gitlab.com/cix-linux/cix_opensource/isp_driver/
    [1]: https://github.com/radxa/kernel/blob/7a822ac9aea389869a28f259b507ceaf5fa4f527/arch/arm64/configs/cix.config#L180-L181
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>