### PR TITLE
feat: cix linux kernel also provides cix-csidma-driver

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,8 @@ Package: linux-image-orion-o6
 Architecture: all
 Section: kernel
 Priority: optional
-Provides: linux-image
+Provides: linux-image,
+          cix-csidma-driver,
 Depends: radxa-overlays-dkms,
          linux-image-${binary:Version}-sky1,
          ${misc:Depends},
@@ -48,7 +49,8 @@ Package: linux-image-radxa-orion-cix-p1
 Architecture: all
 Section: kernel
 Priority: optional
-Provides: linux-image
+Provides: linux-image,
+          cix-csidma-driver,
 Depends: radxa-overlays-dkms,
          linux-image-${binary:Version}-sky1,
          ${misc:Depends},


### PR DESCRIPTION
    feat: cix linux kernel also provides cix-csidma-driver

    The issue is that when we tried to install the `task-cix-isp` package[0]
    using:
    ```
    sudo apt install task-cix-isp
    ```
    
    One of the error we got is:
    ```
    Depends: cix-csidma-driver but it is not installable
    ```
    
    On the Cix OS, we found the `cix-csidma-driver` package with the
    following content:
    ```
    $ dpkg -L cix-csidma-driver
    /.
    /lib
    /lib/modules
    /lib/modules/6.6.89-cix-build-generic
    /lib/modules/6.6.89-cix-build-generic/extra
    /lib/modules/6.6.89-cix-build-generic/extra/csi_dma.ko
    /lib/modules/6.6.89-cix-build-generic/extra/csi_mipi_csi2.ko
    /lib/modules/6.6.89-cix-build-generic/extra/csi_mipi_dphy_hw.ko
    /lib/modules/6.6.89-cix-build-generic/extra/csi_mipi_dphy_rx.ko
    /lib/modules/6.6.89-cix-build-generic/extra/csi_rcsu_hw.ko
    /usr
    /usr/share
    /usr/share/doc
    /usr/share/doc/cix-csidma-driver
    /usr/share/doc/cix-csidma-driver/changelog.Debian.gz
    ```
    On Radxa OS, the ko files mentioned above are in the
    `linux-image-6.6.89-2-sky1_6.6.89-2_arm64.deb` package[1]. If we want to
    keep the compatibility with the Cix SDK packages, we shouldn't remove
    the `cix-csidma-driver` dependency requirement of `task-cix-isp`.
    Therefore, we should mention that the content of `cix-csidma-driver` is
    provided by the kernel package to ensure `task-cix-isp`'s requirement
    can be satisfied.
    
    [0]: https://github.com/radxa-pkg/cix-profiles/blob/3a63fb5c3b2a307a23815ac301023574be4217c4/debian/control#L62-L72
    [1]: https://github.com/radxa-pkg/linux-sky1/releases/download/6.6.89-2/linux-image-6.6.89-2-sky1_6.6.89-2_arm64.deb
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>